### PR TITLE
[SC] Support "query" and "path" parameters in path method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 openapi.json
 host.php
 run.php
+example.php

--- a/src/Entities/Methods/Method.php
+++ b/src/Entities/Methods/Method.php
@@ -2,6 +2,8 @@
 
 namespace Somecode\OpenApi\Entities\Methods;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Somecode\OpenApi\Entities\Parameters\Parameter;
 use Somecode\OpenApi\Enums\RequestMethod;
 
 abstract class Method
@@ -14,10 +16,13 @@ abstract class Method
 
     private string $operationId;
 
+    private ArrayCollection $parameters;
+
     public function __construct()
     {
         // TODO: mb need use other method for generate operationId
         $this->operationId = uniqid();
+        $this->parameters = new ArrayCollection();
     }
 
     public static function create(): static
@@ -64,6 +69,31 @@ abstract class Method
     public function getOperationId(): string
     {
         return $this->operationId;
+    }
+
+    public function addParameter(Parameter $parameter): Method
+    {
+        $this->parameters->add($parameter);
+
+        return $this;
+    }
+
+    public function getParameters(): ArrayCollection
+    {
+        return $this->parameters;
+    }
+
+    public function toArray()
+    {
+        return [
+            'tags' => $this->tags,
+            'summary' => $this->summary,
+            'description' => $this->description,
+            'operationId' => $this->operationId,
+            'parameters' => $this->parameters->map(
+                fn (Parameter $parameter) => $parameter->toArray()
+            )->toArray(),
+        ];
     }
 
     abstract public function method(): RequestMethod;

--- a/src/Entities/Methods/Method.php
+++ b/src/Entities/Methods/Method.php
@@ -83,7 +83,7 @@ abstract class Method
         return $this->parameters;
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'tags' => $this->tags,

--- a/src/Entities/Parameters/Parameter.php
+++ b/src/Entities/Parameters/Parameter.php
@@ -31,6 +31,11 @@ abstract class Parameter
         $this->examples = new ArrayCollection();
     }
 
+    public static function create(): static
+    {
+        return new static();
+    }
+
     public function getName(): string
     {
         return $this->name;
@@ -166,6 +171,24 @@ abstract class Parameter
         $this->explode = true;
 
         return $this;
+    }
+
+    public function toArray(): array
+    {
+        // TODO: implement other properties
+
+        return [
+            'in' => $this->type()->value,
+            'name' => $this->name,
+            'description' => $this->description,
+            'required' => $this->required,
+            'deprecated' => $this->deprecated,
+            // 'schema' => $this->schema,
+            'example' => $this->example,
+            // 'examples' => $this->examples->toArray(),
+            // 'style' => $this->style,
+            // 'explode' => $this->explode,
+        ];
     }
 
     abstract public function type(): ParameterType;

--- a/src/Entities/Parameters/Parameter.php
+++ b/src/Entities/Parameters/Parameter.php
@@ -20,16 +20,23 @@ abstract class Parameter
 
     private mixed $example;
 
+    /** @var ArrayCollection<ParameterExample[]> */
     private ArrayCollection $examples;
 
     private string $style;
 
-    private bool $explode;
+    private bool $explode = false;
 
     public function __construct()
     {
         $this->examples = new ArrayCollection();
     }
+
+    abstract public function type(): ParameterType;
+
+    abstract protected function specificData(): array;
+
+    abstract protected function defaultStyle(): string;
 
     public static function create(): static
     {
@@ -134,7 +141,6 @@ abstract class Parameter
         return $this->examples;
     }
 
-    // TODO: implement addExample method
     public function addExample($example): Parameter
     {
         $this->examples->add($example);
@@ -145,13 +151,6 @@ abstract class Parameter
     public function getStyle(): string
     {
         return $this->style;
-    }
-
-    public function style(string $style): Parameter
-    {
-        $this->style = $style;
-
-        return $this;
     }
 
     public function isExplode(): bool
@@ -177,7 +176,7 @@ abstract class Parameter
     {
         // TODO: implement other properties
 
-        return [
+        return array_merge([
             'in' => $this->type()->value,
             'name' => $this->name,
             'description' => $this->description,
@@ -185,11 +184,28 @@ abstract class Parameter
             'deprecated' => $this->deprecated,
             // 'schema' => $this->schema,
             'example' => $this->example,
-            // 'examples' => $this->examples->toArray(),
-            // 'style' => $this->style,
-            // 'explode' => $this->explode,
-        ];
+            'examples' => $this->getExamplesAsArray(),
+            'style' => $this->style ?? $this->defaultStyle(),
+            'explode' => $this->explode,
+        ], $this->specificData());
     }
 
-    abstract public function type(): ParameterType;
+    protected function setStyle(string $style): static
+    {
+        $this->style = $style;
+
+        return $this;
+    }
+
+    private function getExamplesAsArray(): array
+    {
+        $examples = [];
+
+        /** @var ParameterExample $example */
+        foreach ($this->examples as $example) {
+            $examples[$example->getName()] = $example->toArray();
+        }
+
+        return $examples;
+    }
 }

--- a/src/Entities/Parameters/Parameter.php
+++ b/src/Entities/Parameters/Parameter.php
@@ -176,18 +176,26 @@ abstract class Parameter
     {
         // TODO: implement other properties
 
-        return array_merge([
+        $data = [
             'in' => $this->type()->value,
             'name' => $this->name,
             'description' => $this->description,
             'required' => $this->required,
             'deprecated' => $this->deprecated,
             // 'schema' => $this->schema,
-            'example' => $this->example,
-            'examples' => $this->getExamplesAsArray(),
             'style' => $this->style ?? $this->defaultStyle(),
             'explode' => $this->explode,
-        ], $this->specificData());
+        ];
+
+        if (isset($this->example)) {
+            $data['example'] = $this->example;
+        }
+
+        if (count($this->examples) > 0) {
+            $data['examples'] = $this->getExamplesAsArray();
+        }
+
+        return array_merge($data, $this->specificData());
     }
 
     protected function setStyle(string $style): static

--- a/src/Entities/Parameters/Parameter.php
+++ b/src/Entities/Parameters/Parameter.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Somecode\OpenApi\Entities\Parameters;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Somecode\OpenApi\Enums\ParameterType;
+
+abstract class Parameter
+{
+    private string $name;
+
+    private ?string $description = null;
+
+    private bool $required = false;
+
+    private bool $deprecated = false;
+
+    // TODO: implement after Schema class is implemented
+    private $schema;
+
+    private mixed $example;
+
+    private ArrayCollection $examples;
+
+    private string $style;
+
+    private bool $explode;
+
+    public function __construct()
+    {
+        $this->examples = new ArrayCollection();
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function name(string $name): Parameter
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function description(?string $description): Parameter
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function isRequired(): bool
+    {
+        return $this->required;
+    }
+
+    public function setRequired(bool $required): Parameter
+    {
+        $this->required = $required;
+
+        return $this;
+    }
+
+    public function asRequired(): static
+    {
+        $this->required = true;
+
+        return $this;
+    }
+
+    public function isDeprecated(): bool
+    {
+        return $this->deprecated;
+    }
+
+    public function setDeprecated(bool $deprecated): Parameter
+    {
+        $this->deprecated = $deprecated;
+
+        return $this;
+    }
+
+    public function asDeprecated(): Parameter
+    {
+        $this->deprecated = true;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getSchema()
+    {
+        return $this->schema;
+    }
+
+    /**
+     * @param  mixed  $schema
+     * @return Parameter
+     */
+    public function setSchema($schema)
+    {
+        $this->schema = $schema;
+
+        return $this;
+    }
+
+    public function getExample(): mixed
+    {
+        return $this->example;
+    }
+
+    public function example(mixed $example): Parameter
+    {
+        $this->example = $example;
+
+        return $this;
+    }
+
+    public function getExamples(): ArrayCollection
+    {
+        return $this->examples;
+    }
+
+    // TODO: implement addExample method
+    public function addExample($example): Parameter
+    {
+        $this->examples->add($example);
+
+        return $this;
+    }
+
+    public function getStyle(): string
+    {
+        return $this->style;
+    }
+
+    public function style(string $style): Parameter
+    {
+        $this->style = $style;
+
+        return $this;
+    }
+
+    public function isExplode(): bool
+    {
+        return $this->explode;
+    }
+
+    public function setExplode(bool $explode): Parameter
+    {
+        $this->explode = $explode;
+
+        return $this;
+    }
+
+    public function asExplode(): Parameter
+    {
+        $this->explode = true;
+
+        return $this;
+    }
+
+    abstract public function type(): ParameterType;
+}

--- a/src/Entities/Parameters/Parameter.php
+++ b/src/Entities/Parameters/Parameter.php
@@ -141,9 +141,22 @@ abstract class Parameter
         return $this->examples;
     }
 
-    public function addExample($example): Parameter
+    public function addExample(ParameterExample $example): Parameter
     {
         $this->examples->add($example);
+
+        return $this;
+    }
+
+    /**
+     * @param  array<ParameterExample>  $examples
+     * @return $this
+     */
+    public function addExamples(array $examples): Parameter
+    {
+        foreach ($examples as $example) {
+            $this->addExample($example);
+        }
 
         return $this;
     }

--- a/src/Entities/Parameters/ParameterExample.php
+++ b/src/Entities/Parameters/ParameterExample.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Somecode\OpenApi\Entities\Parameters;
+
+class ParameterExample
+{
+    private string $name;
+
+    private ?string $summary = null;
+
+    private mixed $value;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function name(string $name): ParameterExample
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getSummary(): ?string
+    {
+        return $this->summary;
+    }
+
+    public function summary(?string $summary): ParameterExample
+    {
+        $this->summary = $summary;
+
+        return $this;
+    }
+
+    public function getValue(): mixed
+    {
+        return $this->value;
+    }
+
+    public function value(mixed $value): ParameterExample
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+}

--- a/src/Entities/Parameters/ParameterExample.php
+++ b/src/Entities/Parameters/ParameterExample.php
@@ -10,6 +10,11 @@ class ParameterExample
 
     private mixed $value;
 
+    public static function create(): static
+    {
+        return new static();
+    }
+
     public function getName(): string
     {
         return $this->name;
@@ -44,5 +49,13 @@ class ParameterExample
         $this->value = $value;
 
         return $this;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'summary' => $this->summary,
+            'value' => $this->value,
+        ];
     }
 }

--- a/src/Entities/Parameters/PathParameter.php
+++ b/src/Entities/Parameters/PathParameter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Somecode\OpenApi\Entities\Parameters;
+
+use Somecode\OpenApi\Entities\Parameters\Styles\LabelStyle;
+use Somecode\OpenApi\Entities\Parameters\Styles\MatrixStyle;
+use Somecode\OpenApi\Entities\Parameters\Styles\SimpleStyle;
+use Somecode\OpenApi\Enums\ParameterType;
+
+class PathParameter extends Parameter
+{
+    use LabelStyle, MatrixStyle, SimpleStyle;
+
+    public function type(): ParameterType
+    {
+        return ParameterType::Path;
+    }
+
+    protected function specificData(): array
+    {
+        return [
+            'required' => true,
+        ];
+    }
+
+    protected function defaultStyle(): string
+    {
+        return 'simple';
+    }
+}

--- a/src/Entities/Parameters/QueryParameter.php
+++ b/src/Entities/Parameters/QueryParameter.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Somecode\OpenApi\Entities\Parameters;
+
+use Somecode\OpenApi\Enums\ParameterType;
+
+class QueryParameter extends Parameter
+{
+    public function type(): ParameterType
+    {
+        return ParameterType::Query;
+    }
+}

--- a/src/Entities/Parameters/QueryParameter.php
+++ b/src/Entities/Parameters/QueryParameter.php
@@ -2,12 +2,59 @@
 
 namespace Somecode\OpenApi\Entities\Parameters;
 
+use Somecode\OpenApi\Entities\Parameters\Styles\DeepObjectStyle;
+use Somecode\OpenApi\Entities\Parameters\Styles\FormStyle;
+use Somecode\OpenApi\Entities\Parameters\Styles\PipeDelimitedStyle;
+use Somecode\OpenApi\Entities\Parameters\Styles\SpaceDelimitedStyle;
 use Somecode\OpenApi\Enums\ParameterType;
 
 class QueryParameter extends Parameter
 {
+    use DeepObjectStyle, FormStyle, PipeDelimitedStyle, SpaceDelimitedStyle;
+
+    private bool $allowEmptyValue = false;
+
+    private bool $allowReserved = false;
+
     public function type(): ParameterType
     {
         return ParameterType::Query;
+    }
+
+    protected function specificData(): array
+    {
+        return [
+            'allowEmptyValue' => $this->allowEmptyValue,
+            'allowReserved' => $this->allowReserved,
+        ];
+    }
+
+    protected function defaultStyle(): string
+    {
+        return 'form';
+    }
+
+    public function isAllowEmptyValue(): bool
+    {
+        return $this->allowEmptyValue;
+    }
+
+    public function allowEmptyValue(bool $allowEmptyValue = true): QueryParameter
+    {
+        $this->allowEmptyValue = $allowEmptyValue;
+
+        return $this;
+    }
+
+    public function isAllowReserved(): bool
+    {
+        return $this->allowReserved;
+    }
+
+    public function allowReserved(bool $allowReserved = true): QueryParameter
+    {
+        $this->allowReserved = $allowReserved;
+
+        return $this;
     }
 }

--- a/src/Entities/Parameters/Styles/DeepObjectStyle.php
+++ b/src/Entities/Parameters/Styles/DeepObjectStyle.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Somecode\OpenApi\Entities\Parameters\Styles;
+
+trait DeepObjectStyle
+{
+    public function useDeepObjectStyle(): static
+    {
+        $this->setStyle('deepObject');
+
+        return $this;
+    }
+}

--- a/src/Entities/Parameters/Styles/FormStyle.php
+++ b/src/Entities/Parameters/Styles/FormStyle.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Somecode\OpenApi\Entities\Parameters\Styles;
+
+trait FormStyle
+{
+    public function useFormStyle(): static
+    {
+        $this->setStyle('form');
+
+        return $this;
+    }
+}

--- a/src/Entities/Parameters/Styles/LabelStyle.php
+++ b/src/Entities/Parameters/Styles/LabelStyle.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Somecode\OpenApi\Entities\Parameters\Styles;
+
+trait LabelStyle
+{
+    public function useLabelStyle(): static
+    {
+        $this->setStyle('label');
+
+        return $this;
+    }
+}

--- a/src/Entities/Parameters/Styles/MatrixStyle.php
+++ b/src/Entities/Parameters/Styles/MatrixStyle.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Somecode\OpenApi\Entities\Parameters\Styles;
+
+trait MatrixStyle
+{
+    public function useMatrixStyle(): static
+    {
+        $this->setStyle('matrix');
+
+        return $this;
+    }
+}

--- a/src/Entities/Parameters/Styles/PipeDelimitedStyle.php
+++ b/src/Entities/Parameters/Styles/PipeDelimitedStyle.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Somecode\OpenApi\Entities\Parameters\Styles;
+
+trait PipeDelimitedStyle
+{
+    public function usePipeDelimitedStyle(): static
+    {
+        $this->setStyle('pipeDelimited');
+
+        return $this;
+    }
+}

--- a/src/Entities/Parameters/Styles/SimpleStyle.php
+++ b/src/Entities/Parameters/Styles/SimpleStyle.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Somecode\OpenApi\Entities\Parameters\Styles;
+
+trait SimpleStyle
+{
+    public function useSimpleStyle(): static
+    {
+        $this->setStyle('simple');
+
+        return $this;
+    }
+}

--- a/src/Entities/Parameters/Styles/SpaceDelimitedStyle.php
+++ b/src/Entities/Parameters/Styles/SpaceDelimitedStyle.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Somecode\OpenApi\Entities\Parameters\Styles;
+
+trait SpaceDelimitedStyle
+{
+    public function useSpaceDelimitedStyle(): static
+    {
+        $this->setStyle('spaceDelimited');
+
+        return $this;
+    }
+}

--- a/src/Entities/Path.php
+++ b/src/Entities/Path.php
@@ -38,4 +38,16 @@ class Path
 
         return $this;
     }
+
+    public function toArray(): array
+    {
+        $data = [];
+
+        /** @var Method $method */
+        foreach ($this->methods as $method) {
+            $data[strtolower($method->method()->value)] = $method->toArray();
+        }
+
+        return $data;
+    }
 }

--- a/src/Enums/ParameterType.php
+++ b/src/Enums/ParameterType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Somecode\OpenApi\Enums;
+
+enum ParameterType: string
+{
+    case Query = 'query';
+    case Path = 'path';
+    case Header = 'header';
+    case Cookie = 'cookie';
+}

--- a/src/Services/JsonSerializer.php
+++ b/src/Services/JsonSerializer.php
@@ -3,6 +3,7 @@
 namespace Somecode\OpenApi\Services;
 
 use Somecode\OpenApi\Builder;
+use Somecode\OpenApi\Entities\Path;
 
 class JsonSerializer
 {
@@ -19,7 +20,19 @@ class JsonSerializer
                 'version' => $this->builder->info()->getVersion(),
                 'description' => $this->builder->info()->getDescription(),
             ],
-            'paths' => [],
-        ], JSON_PRETTY_PRINT);
+            'paths' => $this->paths(),
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+
+    private function paths(): array
+    {
+        $paths = [];
+
+        /** @var Path $path */
+        foreach ($this->builder->paths() as $path) {
+            $paths[$path->uri()] = $path->toArray();
+        }
+
+        return $paths;
     }
 }


### PR DESCRIPTION
In the first iteration, we will add support for Query and Path parameters.

```php
use Somecode\OpenApi\Builder;
use Somecode\OpenApi\Entities\Methods\Get;
use Somecode\OpenApi\Entities\Parameters\ParameterExample;
use Somecode\OpenApi\Entities\Parameters\PathParameter;
use Somecode\OpenApi\Entities\Parameters\QueryParameter;
use Somecode\OpenApi\Entities\Path;

$builder = new Builder(
    title: 'Ozon',
    version: '1.0.0',
    description: 'Ozon API documentation'
);

$path = Path::create('/api/products/{product}')
    ->addMethod(
        Get::create()
            ->tags(['Products'])
            ->summary('Get product details')
            ->addParameter(
                PathParameter::create()
                    ->name('product')
                    ->description('Product identifier')
            )
            ->addParameter(
                QueryParameter::create()
                    ->name('details')
                    ->description('Product details')
                    ->example('full')
                    ->addExamples([
                        ParameterExample::create()
                            ->name('full')
                            ->summary('Full')
                            ->value('full'),
                        ParameterExample::create()
                            ->name('minified')
                            ->summary('Minified')
                            ->value('minified'),
                    ])
            )
    );

$builder->addPath($path);
```